### PR TITLE
Add module "effector-storage" && Fix readme.md:68-69 dots

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Found something cool? Please, **[contribute](contributing.md)**!
 ### Form management
 * [effector-forms](https://github.com/aanation/effector-forms) - Form manager for effector.
 * [efform](https://github.com/tehSLy/efform) - Form manager, based on effector state manager, designed to deliver high-quality DX.
-* [effector-react-form](https://github.com/GTOsss/effector-react-form)
+* [effector-react-form](https://github.com/GTOsss/effector-react-form) — Alternate form manager.
 
 ## Templates
 * [effector SSR](https://github.com/effector/razzle-template) - SSR on React, TypeScript, Razzle and Styled.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Found something cool? Please, **[contribute](contributing.md)**!
 * [effector-undo](https://github.com/tanyaisinmybed/effector-undo) - Simple undo/redo functionality for effector.
 * [effector-utils](https://github.com/Kelin2025/effector-utils) - Effector utilities library.
 * [effector-next](https://github.com/effector/nextjs) - Effector wrappers for Next.js.
+* [effector-storage](https://github.com/yumauri/effector-storage) - Module for Effector that sync stores with localStorage (or sessionStorage)
 * [forest](https://github.com/effector/effector/tree/master/packages/forest) - UI engine for web based on effector.
 * [@space307/effector-react-slots](https://github.com/space307/effector-react-slots) - Effector library for slots implementation in React.
 

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Found something cool? Please, **[contribute](contributing.md)**!
 * [patronum](https://github.com/effector/patronum) - Effector utility library delivering modularity and convenience.
 * [atomic-router](https://github.com/atomic-router) - Simple routing implementation that provides abstraction layer instead of inline URL's and does not break your architecture.
 * [eslint-plugin-effector](https://github.com/effector/eslint-plugin) - Enforcing best practices.
-* [effector-factorio](https://github.com/Kelin2025/effector-factorio) - The simplest way to write re-usable features with React + Effector
-* [effector-hotkey](https://github.com/Kelin2025/effector-hotkey) - Hotkeys with Effector made easy
+* [effector-factorio](https://github.com/Kelin2025/effector-factorio) - The simplest way to write re-usable features with React + Effector.
+* [effector-hotkey](https://github.com/Kelin2025/effector-hotkey) - Hotkeys with Effector made easy.
 * [effector-localstorage](https://github.com/lessmess-dev/effector-localstorage) - Module for effector that sync stores with localStorage.
 * [effector-undo](https://github.com/tanyaisinmybed/effector-undo) - Simple undo/redo functionality for effector.
 * [effector-utils](https://github.com/Kelin2025/effector-utils) - Effector utilities library.

--- a/README.md
+++ b/README.md
@@ -71,14 +71,14 @@ Found something cool? Please, **[contribute](contributing.md)**!
 * [effector-undo](https://github.com/tanyaisinmybed/effector-undo) - Simple undo/redo functionality for effector.
 * [effector-utils](https://github.com/Kelin2025/effector-utils) - Effector utilities library.
 * [effector-next](https://github.com/effector/nextjs) - Effector wrappers for Next.js.
-* [effector-storage](https://github.com/yumauri/effector-storage) - Module for Effector that sync stores with localStorage (or sessionStorage)
+* [effector-storage](https://github.com/yumauri/effector-storage) - Module for Effector that sync stores with localStorage (or sessionStorage).
 * [forest](https://github.com/effector/effector/tree/master/packages/forest) - UI engine for web based on effector.
 * [@space307/effector-react-slots](https://github.com/space307/effector-react-slots) - Effector library for slots implementation in React.
 
 ### Form management
 * [effector-forms](https://github.com/aanation/effector-forms) - Form manager for effector.
 * [efform](https://github.com/tehSLy/efform) - Form manager, based on effector state manager, designed to deliver high-quality DX.
-* [effector-react-form](https://github.com/GTOsss/effector-react-form) — Alternate form manager.
+* [effector-react-form](https://github.com/GTOsss/effector-react-form) - Alternate form manager.
 
 ## Templates
 * [effector SSR](https://github.com/effector/razzle-template) - SSR on React, TypeScript, Razzle and Styled.


### PR DESCRIPTION
- Added `effector-storage` (module for sync stores with localStorage, sessionStorage etc.) to "packages" section
- Added dots to ends of lines [README.md:68 and README.md:69](https://github.com/effector/awesome/pull/23/commits/e4447d1ee863f4095d58d408551307745b6c8a84#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L68-L69)